### PR TITLE
Fix video embeds

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -172,7 +172,7 @@ $('#photoembedcode_form').submit(function(e) {
 
 
 function videoEmbed(video, width, height) {
-  var codeBlock = '<figure class="op-social video story_relatedvideo" itemprop="associatedMedia" style="margin: 0 0 1em 0;"><div class="youtube"><iframe width="' + width + '" height="' + height + '"  src="' + video + '" frameborder="0" allowfullscreen></iframe></div></figure>';
+  var codeBlock = '<figure class="op-social story_relatedvideo" itemprop="associatedMedia" style="margin: 0 0 1em 0;"><div class="video"><div class="youtube"><iframe width="' + width + '" height="' + height + '"  src="' + video + '" frameborder="0" allowfullscreen></iframe></div></div></figure>';
 
   return codeBlock;
 }
@@ -182,6 +182,11 @@ $('#videoembedcode_form').submit(function(e) {
       width = $('#videoWidth').val(),
       height = $('#videoHeight').val(),
       video = 'https://www.youtube.com/embed/' + videoID;
+
+  if (width === '' && height === '') {
+    width = 560;
+    height = 315;
+  }
 
   var codeBlock = videoEmbed(video, width, height);
   returnCode (codeBlock, 'videoembedcode');


### PR DESCRIPTION
Because FitVids is looking specifically for a div with a class of "video", updated the code to reflect that instead of placing the "video" class on the updated figure element.

I also added fallbacks for height and width, as videos seemed to be looking funky and small without it set. I'm guessing this is also related to switching over to using the figure element here.

To test this, copy and place a video inside of a story both with and without height and width set, and confirm that in the story, you see the video looks correct and it is acting responsively, as expected.
