### PR TITLE
Add data-feedback for fb likes, shares, comments for images and videos

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -144,7 +144,7 @@ $('#pulltextcode_form').submit(function(e) {
 
 
 function photoEmbed(url, credit, caption, positionFloat) {
-  var codeBlock = '<figure style="line-height: 1.3;" class="story_image--inline media article_detail unprose' +positionFloat + ' data-feedback="fb:likes,fb:comments"><img src="' + url + '" style="width: 100%;" /><figcaption style="color: #4a4a4a; font-family: Helvetica, Arial, sans-serif; font-size: 0.8em;">' + caption + '<cite style="color: #222222; font-family: Helvetica, Arial, sans-serif; font-size: 0.7em; letter-spacing: 0.03em; padding-left: 1em; text-transform: uppercase;">' + credit + '</cite>'+ '</figcaption></figure>';
+  var codeBlock = '<figure class="story_image--inline media article_detail unprose' +positionFloat + ' data-feedback="fb:likes,fb:comments"><img src="' + url + '" style="width: 100%;" /><figcaption style="color: #4a4a4a; font-family: Helvetica, Arial, sans-serif; font-size: 0.8em; line-height: 1.3;">' + caption + '<cite style="color: #222222; font-family: Helvetica, Arial, sans-serif; font-size: 0.7em; letter-spacing: 0.03em; line-height: 1.3; padding-left: 1em; text-transform: uppercase;">' + credit + '</cite>'+ '</figcaption></figure>';
 
   return codeBlock;
 }
@@ -172,7 +172,7 @@ $('#photoembedcode_form').submit(function(e) {
 
 
 function videoEmbed(video, width, height) {
-  var codeBlock = '<figure class="op-social story_relatedvideo" itemprop="associatedMedia" style="margin: 0 0 1em 0;" data-feedback="fb:likes,fb:comments"><div class="video"><div class="youtube"><iframe width="' + width + '" height="' + height + '"  src="' + video + '" frameborder="0" allowfullscreen></iframe></div></div></figure>';
+  var codeBlock = '<figure class="op-social story_relatedvideo" itemprop="associatedMedia" style="margin: 0 0 1em 0;"><div class="video"><div class="youtube"><iframe width="' + width + '" height="' + height + '"  src="' + video + '" frameborder="0" allowfullscreen></iframe></div></div></figure>';
 
   return codeBlock;
 }


### PR DESCRIPTION
#### What's this PR do?

Adds data-feedback attributes to embedded images and videos so that when they make it through to FBIA, it is possible for folks to share, like, and comment on the embedded images and videos themselves.
#### Why are we doing this? How does it help us?

Adding the option to share, like, and comment on these elements potentially allows people to engage with our content in a more fine-tuned manner and could help us reach more people on FB, which is already a popular spot for us.
#### How should this be manually tested?

Place an embedded image from code-grabber inside of an example story and check it still looks as expected.

Do the same with an embedded video.

I have set up a test story in our development FBIA feed to test that the share, like, and comment functionality have been transferred through to there as expected. If you have the Pages manager app, you can take a look at a test story with these shareable and commentable images and videos embedded inside. Also feel free to ask me to show you.
#### Have automated tests been added?

no
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

no
#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/143301585
#### How should this change be communicated to end users?

Tell Rodney to look out for action we're getting from this.
#### Next steps?
#### Smells?
#### TODOs:
#### Has the relevant documentation/wiki been updated?
#### Technical debt note

Same
