### PR TITLE
change to encodeURIcomponent()

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -64,7 +64,7 @@ function twitterinline(sentence, sentenceEncode, hashtag) {
 
 $('#twitterinlinecode_form').submit(function(e) {
   var shareSentence = $('#twitterinline_sentence').val(),
-      shareSentenceEncoded = encodeURI(shareSentence),
+      shareSentenceEncoded = encodeURIComponent(shareSentence),
       shareHashtag = $('#twitterinline_hashtag').val().replace(/\s+/g, ''),
       codeBlock = twitterinline(shareSentence, shareSentenceEncoded, shareHashtag),
       shareSentenceLength = shareSentence.length,


### PR DESCRIPTION
#### What's this PR do?

Fixes issue #25 by `encodingURIcomponents()` in Twitter share sentences
#### Why are we doing this? How does it help us?

Because it's currently broken. And bad things happen.
#### How should this be manually tested?

Try putting a link with special characters like & in a story page.
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?
#### What are the relevant tickets?
#25
