### PR TITLE
change language to video, rm height/width values

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -171,24 +171,16 @@ $('#photoembedcode_form').submit(function(e) {
 });
 
 
-function videoEmbed(video, width, height) {
-  var codeBlock = '<figure class="op-social story_relatedvideo" itemprop="associatedMedia" style="margin: 0 0 1em 0;"><div class="video"><div class="youtube"><iframe width="' + width + '" height="' + height + '"  src="' + video + '" frameborder="0" allowfullscreen></iframe></div></div></figure>';
+function videoEmbed(videoID) {
+  var codeBlock = '<figure class="op-social story_relatedvideo" itemprop="associatedMedia" style="margin: 0 0 1em 0;"><div class="video"><div class="youtube"><iframe src="https://www.youtube.com/embed/' + videoID + '" frameborder="0" allowfullscreen></iframe></div></div></figure>';
 
   return codeBlock;
 }
 
 $('#videoembedcode_form').submit(function(e) {
-  var videoID = $('#videoID').val(),
-      width = $('#videoWidth').val(),
-      height = $('#videoHeight').val(),
-      video = 'https://www.youtube.com/embed/' + videoID;
+  var videoID = $('#videoID').val();
 
-  if (width === '' && height === '') {
-    width = 560;
-    height = 315;
-  }
-
-  var codeBlock = videoEmbed(video, width, height);
+  var codeBlock = videoEmbed(videoID);
   returnCode (codeBlock, 'videoembedcode');
 
   copied(this.id);

--- a/app/templates/includes/video_embed.html
+++ b/app/templates/includes/video_embed.html
@@ -1,17 +1,14 @@
 <!-- Video Embed     -->
   <section id="video_embed" class="section--block">
     <header>
-      <h2>Responsive Video Embed</h2>
-      <p>These code blocks rely on CMS classes to load FitVids.js and make the videos responsive. All videos should be YouTube videos. You don't need to set a width or height &mdash; but dimensions will get funky if you set one and not the other.</p>
+      <h2>Responsive YouTube Embed</h2>
+      <p>These code blocks rely on CMS classes to load FitVids.js and make YouTube videos responsive. All videos should be YouTube videos.</p>
+      <p>Insert the video ID into the form below — NOT THE URL FOR THE VIDEO.</p>
     </header>
 
     {% set videoembedform %}
     <label>Video ID - Ex: BtZF007Lep4</label>
     <input id="videoID" type="text" value="" required>
-    <label>Width</label>
-    <input id="videoWidth" type="text" value="">
-    <label>Height</label>
-    <input id="videoHeight" type="text" value="">
     {% endset %}
 
     {{ macro.copyBlock('videoembedcode', videoembedform)}}


### PR DESCRIPTION
### What's this PR do?

Remove width/height from the video form. Adjust language to ensure only YouTube videos are used, and people know to put only the video ID, not the whole video URL.
#### Why are we doing this? How does it help us?

Remove confusion.
#### What are the relevant tickets?
#27
